### PR TITLE
Replaced bytes.Buffer with strings.Builder

### DIFF
--- a/clickhouse/query.go
+++ b/clickhouse/query.go
@@ -1,7 +1,6 @@
 package clickhouse
 
 import (
-	"bytes"
 	"errors"
 	"fmt"
 	"strings"
@@ -24,7 +23,7 @@ func formatInsert(database string, table string) string {
 }
 
 type sqlBuilder struct {
-	sqlStr   bytes.Buffer
+	sqlStr   strings.Builder
 	query    *prompb.Query
 	database string
 	table    string


### PR DESCRIPTION
strings.Builder is more efficient in scopes of time and memory, see https://medium.com/@felipedutratine/string-concatenation-in-golang-since-1-10-bytes-buffer-vs-strings-builder-2b3081848c45 for more info.

Signed-off-by: Yury Frolov <yura200253@gmail.com>